### PR TITLE
Update to use higher level ti helper image getter

### DIFF
--- a/src/com/alcoapps/actionbarextras/ActionbarextrasModule.java
+++ b/src/com/alcoapps/actionbarextras/ActionbarextrasModule.java
@@ -448,9 +448,9 @@ public class ActionbarextrasModule extends KrollModule {
 			return;
 		}
 		
-		int resId = TiUIHelper.getResourceId(resolveUrl(null, icon));
-		if (resId != 0) {
-			actionBar.setHomeAsUpIndicator(resId);
+		Drawable drawableIcon = TiUIHelper.getResourceDrawable(icon);
+		if (drawableIcon != null) {
+			actionBar.setHomeAsUpIndicator(drawableIcon);
 		} else {
 			Log.e(TAG, "Couldn't resolve " + icon);
 		}


### PR DESCRIPTION
With reference to http://developer.android.com/reference/android/app/ActionBar.html#setHomeAsUpIndicator%28android.graphics.drawable.Drawable%29 a drawable can be passed to setHomeAsUpIndicator so we use that helper instead