### PR TITLE
Get the title of the current window

### DIFF
--- a/src/com/alcoapps/actionbarextras/ActionbarextrasModule.java
+++ b/src/com/alcoapps/actionbarextras/ActionbarextrasModule.java
@@ -97,6 +97,12 @@ public class ActionbarextrasModule extends KrollModule {
 			// Ignore
 		}
 	}
+
+	@Kroll.getProperty @Kroll.method
+    	public String getTitle()
+    	{
+        	return getActionBar().getTitle().toString();
+    	}
 	
 	private ActionBar getActionBar(){
 		ActionBarActivity activity;


### PR DESCRIPTION
Get the title of the current activity. Titanium doesn't support converting a SpannableString to a String, so I added this method.