### PR TITLE
Fix icon font fill color for Android >= 5

### DIFF
--- a/src/com/alcoapps/actionbarextras/IconDrawable.java
+++ b/src/com/alcoapps/actionbarextras/IconDrawable.java
@@ -69,7 +69,7 @@ public class IconDrawable extends Drawable {
         this.icon = icon;
         paint = new TextPaint();
         paint.setTypeface( typeface );
-        paint.setStyle(Paint.Style.STROKE);
+        paint.setStyle(Paint.Style.FILL_AND_STROKE);
         paint.setTextAlign(Paint.Align.CENTER);
         paint.setUnderlineText(false);
         paint.setColor(Color.BLACK);


### PR DESCRIPTION
Cause the icon drawable paint color previously was only set to style STROKE, icons on Android >= 5 are not filled with a specified color.